### PR TITLE
Fix training time measurement

### DIFF
--- a/train.py
+++ b/train.py
@@ -48,8 +48,10 @@ def main():
     # Train the classifier
     print(f'Training classifier')
     trainer = ModelTrainer(filepath=args.model, contamination=args.contamination, n_jobs=args.n_jobs)
-    
+
     classifier = trainer.train_classifier(feature_results)
+
+    elapsed = time.time() - then
 
     print(f'Trained classifier in {elapsed:.2f} seconds')
 


### PR DESCRIPTION
## Summary
- compute elapsed time immediately after `trainer.train_classifier`

## Testing
- `python -m py_compile train.py score.py dashboard.py models/*.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_685d8185764c832abdfcdfd065e6c706